### PR TITLE
Oauth signatures with a proxy

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,6 +48,7 @@ WooCommerceAPI.prototype._setDefaultsOptions = function(opt) {
   this.verifySsl       = false === opt.verifySsl ? false : true;
   this.encoding        = opt.encoding || 'utf8';
   this.queryStringAuth = opt.queryStringAuth || false;
+  this.proxy           = opt.proxy || false;
 };
 
 /**
@@ -165,7 +166,7 @@ WooCommerceAPI.prototype._request = function(method, endpoint, data, callback) {
     }
   } else {
     params.qs = this._getOAuth().authorize({
-      url: url,
+      url: this.proxy ? this.proxy : url,
       method: method
     });
   }

--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ WooCommerceAPI.prototype._setDefaultsOptions = function(opt) {
   this.verifySsl       = false === opt.verifySsl ? false : true;
   this.encoding        = opt.encoding || 'utf8';
   this.queryStringAuth = opt.queryStringAuth || false;
-  this.proxy           = opt.proxy || false;
+  this.proxy           = opt.proxy || null;
 };
 
 /**

--- a/index.js
+++ b/index.js
@@ -104,6 +104,26 @@ WooCommerceAPI.prototype._getUrl = function(endpoint) {
 };
 
 /**
+ * In case of a proxy use, we need the actual aimed address for building
+ * signature. This function returns the url of the endpoint according to
+ * this actual adress.
+ *
+ * @param {String} endpoint The endpoint aimed for the request
+ *
+ * @returns {String} The URL of the endpoint, with proxy resolution.
+ */
+WooCommerceAPI.prototype._getProxyUrl = function(endpoint) {
+  var url = '/' === this.proxy.slice(-1) ? this.proxy : this.proxy + '/';
+  url = url + 'wc-api/' + this.version + '/' + endpoint;
+
+  if (!this.isSsl) {
+    return this._normalizeQueryString(url);
+  }
+
+  return url;
+}
+
+/**
  * Get OAuth
  *
  * @return {Object}
@@ -166,7 +186,8 @@ WooCommerceAPI.prototype._request = function(method, endpoint, data, callback) {
     }
   } else {
     params.qs = this._getOAuth().authorize({
-      url: this.proxy ? this.proxy : url,
+      // If using a proxy, we need the actual address for signature
+      url: this.proxy ? this._getProxyUrl(endpoint) : url,
       method: method
     });
   }

--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ WooCommerceAPI.prototype._setDefaultsOptions = function(opt) {
   this.verifySsl       = false === opt.verifySsl ? false : true;
   this.encoding        = opt.encoding || 'utf8';
   this.queryStringAuth = opt.queryStringAuth || false;
-  this.proxy           = opt.proxy || null;
+  this.proxy           = opt.proxy || '';
 };
 
 /**
@@ -187,7 +187,7 @@ WooCommerceAPI.prototype._request = function(method, endpoint, data, callback) {
   } else {
     params.qs = this._getOAuth().authorize({
       // If using a proxy, we need the actual address for signature
-      url: this.proxy ? this._getProxyUrl(endpoint) : url,
+      url: this.proxy != '' ? this._getProxyUrl(endpoint) : url,
       method: method
     });
   }


### PR DESCRIPTION
Adding the possibility to add a `proxy` in the options in the initialization of the API.
This is useful if you want to debug your Ionic app in the browser according to [this reference](http://ionicinaction.com/blog/how-to-fix-cors-issues-revisited/).

**Example :**
```javascript
var wc = new WooCommerceAPI({
  consumerKey: 'ck_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
  consumerSecret: 'cs_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',
  url: 'http://localhost:8100/my-proxy/',
  proxy: 'http://myactualsite.com/'
});
```

What I did :
I added a function `getProxyUrl` that returns the url of the endpoint according to the actual url of the website (variable `proxy` in API definition). This function is used instead of `getUrl` in case of a non-null `proxy` initialization when using Oauth to authenticate. This way, the actual address is used instead of the proxy to build the `oauth_signature` (that was my issue https://github.com/woothemes/wc-api-node/issues/14).

Hope it helps