### PR TITLE
Make the wp rest api endpoint prefix customizable

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ var WooCommerceAPI = require('woocommerce-api');
 
 var WooCommerce = new WooCommerceAPI({
   url: 'http://example.com',
-  wpAPI: true,
+  wpAPI: 'wp-json/', // set it to the wp rest api path
   version: 'wc/v1',
   consumerKey: 'ck_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
   consumerSecret: 'cs_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'

--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ var WooCommerceAPI = require('woocommerce-api');
 
 var WooCommerce = new WooCommerceAPI({
   url: 'http://example.com',
-  wpAPI: 'wp-json/', // set it to the wp rest api path
+  wpAPI: true,
+  wpAPIPath: 'wp-rest/', // [optional] the wp rest api path, defaults to 'wp-json/'
   version: 'wc/v1',
   consumerKey: 'ck_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
   consumerSecret: 'cs_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'

--- a/index.js
+++ b/index.js
@@ -42,6 +42,7 @@ function WooCommerceAPI(opt) {
 WooCommerceAPI.prototype._setDefaultsOptions = function(opt) {
   this.url             = opt.url;
   this.wpAPI           = opt.wpAPI || false;
+  this.wpAPIPath       = opt.wpAPIPath || 'wp-json/';
   this.version         = opt.version || 'v3';
   this.isSsl           = /^https/i.test(this.url);
   this.consumerKey     = opt.consumerKey;
@@ -96,7 +97,7 @@ WooCommerceAPI.prototype._normalizeQueryString = function(url) {
  */
 WooCommerceAPI.prototype._getUrl = function(endpoint) {
   var url = '/' === this.url.slice(-1) ? this.url : this.url + '/';
-  var api = this.wpAPI ? this.wpAPI : 'wc-api/';
+  var api = this.wpAPI ? this.wpAPIPath : 'wc-api/';
 
   url = url + api + this.version + '/' + endpoint;
 

--- a/index.js
+++ b/index.js
@@ -96,7 +96,7 @@ WooCommerceAPI.prototype._normalizeQueryString = function(url) {
  */
 WooCommerceAPI.prototype._getUrl = function(endpoint) {
   var url = '/' === this.url.slice(-1) ? this.url : this.url + '/';
-  var api = this.wpAPI ? 'wp-json/' : 'wc-api/';
+  var api = this.wpAPI ? this.wpAPI : 'wc-api/';
 
   url = url + api + this.version + '/' + endpoint;
 


### PR DESCRIPTION
WP REST API allows the developer to customize the api prefix (default is wp-json) with filters like so:

```php
add_filter( 'rest_url_prefix', function () { return 'wp-rest'; } );
```

My suggestion is to use `wpApi` parameter to reflect this behaviour.

example:

```js
const WooCommerce = new WooCommerceAPI({
  url: 'https://local.development.com',
  verifySsl: false,
  wpAPI: 'wp-rest/',
  version: 'wc/v1',
  consumerKey: 'chewbecca',
  consumerSecret: '8jm6BEp09qUX1jsNp8C4/s'
});
```